### PR TITLE
fix: adjust main content top padding to prevent overlap with fixed he…

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -37,7 +37,7 @@ export function MainLayout({ children }: { children: React.ReactNode }) {
     <div className="bg-helena-light min-h-screen">
       <Header />
       <Sidebar />
-      <main className="ml-64 pt-16 p-6">
+      <main className="ml-64 pt-20 p-6">
         {children}
       </main>
     </div>


### PR DESCRIPTION
…ader

- Increased top padding from pt-16 to pt-20 (64px to 80px)
- Ensures main content and sidebar are not hidden behind fixed header
- Resolves layout positioning issue reported by user