### PR TITLE
fix: add missing usePathname import to resolve TypeScript build error

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import { Header } from './Header';
 import { Sidebar } from './Sidebar';
 import { useAuth } from '@/contexts/AuthContext';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 
 export function MainLayout({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth()


### PR DESCRIPTION
- Import usePathname from next/navigation in MainLayout.tsx
- Resolves 'Cannot find name usePathname' TypeScript error
- Ensures Vercel build will complete successfully