### PR TITLE
fix: remove unnecessary React import to resolve 'use client' directiv…

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,8 @@
-import React from 'react'
 'use client'
 
-import { MainLayout } from '@/components/layout/MainLayout';
-import { Mic, Printer, FileText, PenTool, CheckCircle, Users, Clock, Lightbulb } from 'lucide-react';
-import { useState, useEffect } from 'react';
+import { MainLayout } from '@/components/layout/MainLayout'
+import { Mic, Printer, FileText, PenTool, CheckCircle, Users, Clock, Lightbulb } from 'lucide-react'
+import { useState, useEffect } from 'react'
 
 export default function Home() {
   const [transcriptionText, setTranscriptionText] = useState('Aguardando comando de voz...')


### PR DESCRIPTION
…e positioning

- Remove unused React import from src/app/page.tsx
- Ensure 'use client' directive is positioned correctly before other expressions
- Resolves Vercel build error: 'use client' directive must be placed before other expressions