### PR TITLE
fix: update schema type definitions and create RLS policy migration

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -85,33 +85,106 @@ export type Database = {
         Row: {
           id: string
           user_id: string
-          paciente_id: string
-          data: string
-          medicamentos: unknown
-          observacoes: string | null
-          pdf_url: string | null
+          paciente: string
+          medicamento: string
+          posologia: string
+          observacoes: string
+          criado_em: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          paciente: string
+          medicamento: string
+          posologia: string
+          observacoes?: string
+          criado_em?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          paciente?: string
+          medicamento?: string
+          posologia?: string
+          observacoes?: string
+          criado_em?: string
+        }
+      }
+      modelos_prescricao: {
+        Row: {
+          id: string
+          user_id: string
+          nome: string
+          categoria: string | null
+          especialidade: string | null
+          medicamento: string
+          posologia: string
+          observacoes: string
+          ativo: boolean
+          uso_count: number
           created_at: string
           updated_at: string
         }
         Insert: {
           id?: string
           user_id: string
-          paciente_id: string
-          data?: string
-          medicamentos?: unknown
-          observacoes?: string | null
-          pdf_url?: string | null
+          nome: string
+          categoria?: string | null
+          especialidade?: string | null
+          medicamento: string
+          posologia: string
+          observacoes?: string
+          ativo?: boolean
+          uso_count?: number
           created_at?: string
           updated_at?: string
         }
         Update: {
           id?: string
           user_id?: string
-          paciente_id?: string
-          data?: string
-          medicamentos?: unknown
-          observacoes?: string | null
-          pdf_url?: string | null
+          nome?: string
+          categoria?: string | null
+          especialidade?: string | null
+          medicamento?: string
+          posologia?: string
+          observacoes?: string
+          ativo?: boolean
+          uso_count?: number
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      configuracoes_usuario: {
+        Row: {
+          id: string
+          user_id: string
+          tema: string
+          modelo_ia: string
+          notificacoes_email: boolean
+          notificacoes_push: boolean
+          backup_automatico: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          tema?: string
+          modelo_ia?: string
+          notificacoes_email?: boolean
+          notificacoes_push?: boolean
+          backup_automatico?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          tema?: string
+          modelo_ia?: string
+          notificacoes_email?: boolean
+          notificacoes_push?: boolean
+          backup_automatico?: boolean
           created_at?: string
           updated_at?: string
         }

--- a/supabase/migrations/enable_rls_phase1.sql
+++ b/supabase/migrations/enable_rls_phase1.sql
@@ -1,0 +1,16 @@
+ALTER TABLE public.perfis_usuarios ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.pacientes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.modelos_prescricao ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.configuracoes_usuario ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can only see their own profile" ON public.perfis_usuarios
+  FOR ALL USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can only see their own patients" ON public.pacientes
+  FOR ALL USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can only see their own templates" ON public.modelos_prescricao
+  FOR ALL USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can only see their own settings" ON public.configuracoes_usuario
+  FOR ALL USING (auth.uid() = user_id);


### PR DESCRIPTION
- Fix prescricoes table schema to match actual database structure (paciente, medicamento, posologia fields)
- Add missing Phase 1 table definitions (modelos_prescricao, configuracoes_usuario) to supabase.ts
- Create RLS policy migration script for Phase 1 tables
- Resolve schema type mismatches causing potential authentication issues