### PR TITLE
Handle missing OpenAI key gracefully and persist Supabase sessions

### DIFF
--- a/src/app/api/voice/transcribe/route.ts
+++ b/src/app/api/voice/transcribe/route.ts
@@ -3,12 +3,17 @@ import OpenAI from 'openai';
 import { getCurrentUser } from '@/lib/auth';
 import { complianceAuditService } from '@/lib/complianceAuditService';
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
-
 export async function POST(request: NextRequest) {
   try {
+    const apiKey = process.env.OPENAI_API_KEY
+    if (!apiKey) {
+      return NextResponse.json({ error: 'OPENAI_API_KEY não está configurada' }, { status: 500 })
+    }
+
+    const openai = new OpenAI({
+      apiKey: apiKey,
+    })
+
     const user = await getCurrentUser();
     if (!user) {
       return NextResponse.json({ error: 'Não autorizado' }, { status: 401 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { supabase } from './supabase';
 
 export async function signUp(email: string, password: string, userData: {

--- a/src/lib/openaiService.ts
+++ b/src/lib/openaiService.ts
@@ -9,12 +9,14 @@ export interface PrescricaoData {
 }
 
 export class OpenAIService {
-  private openai: OpenAI
+  private openai: OpenAI | null
 
   constructor() {
     const apiKey = process.env.OPENAI_API_KEY
     if (!apiKey) {
-      throw new Error('OPENAI_API_KEY não está definida nas variáveis de ambiente')
+      console.warn('OPENAI_API_KEY não está definida nas variáveis de ambiente')
+      this.openai = null
+      return
     }
 
     this.openai = new OpenAI({
@@ -23,6 +25,9 @@ export class OpenAIService {
   }
 
   async gerarPrescricao(transcricao: string): Promise<PrescricaoData> {
+    if (!this.openai) {
+      throw new Error('OpenAI client não configurado')
+    }
     try {
       const prompt = `
 Você é um assistente médico especializado em interpretar comandos de voz para gerar prescrições médicas estruturadas.
@@ -109,10 +114,13 @@ Exemplo de resposta esperada:
   }
 
   async gerarPrescricaoComContexto(
-    transcricao: string, 
+    transcricao: string,
     pacienteNome: string,
     userId: string
   ): Promise<PrescricaoData> {
+    if (!this.openai) {
+      throw new Error('OpenAI client não configurado')
+    }
     try {
       const historico = await this.getPatientHistory(pacienteNome, userId);
       const contextualPrompt = this.buildContextualPrompt(transcricao, pacienteNome, historico);

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,19 +1,16 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Missing Supabase environment variables')
+  throw new Error('Missing Supabase environment variables');
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-  auth: {
-    persistSession: true,
-    autoRefreshToken: true,
-    detectSessionInUrl: true
-  }
-})
+export const supabase = createClientComponentClient({
+  supabaseUrl,
+  supabaseKey: supabaseAnonKey,
+});
 
 export type Database = {
   public: {


### PR DESCRIPTION
## Summary
- avoid build-time crashes when `OPENAI_API_KEY` is unset by lazily initializing OpenAI clients
- guard voice transcription route and service methods when API key is missing
- persist Supabase sessions with auth-helpers to let API routes authenticate users

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890beea0cec8321be244d2ab007ce22