### PR TITLE
Fix javascript errors and warnings

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,8 @@
 import "./globals.css";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
-import { initializeErrorHandling } from "@/lib/errorHandler";
 import type { Metadata, Viewport } from "next";
+import AppInitializer from "@/components/AppInitializer";
 
 export const metadata: Metadata = {
   title: "Helena - Assistente Médica de Prescrição",
@@ -31,7 +31,7 @@ export default function RootLayout({
     <html lang="pt-BR">
       <head>
         <link rel="manifest" href="/manifest.json" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="apple-mobile-web-app-title" content="Helena" />
         <link rel="apple-touch-icon" href="/icon-192x192.png" />
@@ -42,26 +42,7 @@ export default function RootLayout({
             {children}
           </AuthProvider>
         </ErrorBoundary>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-              if ('serviceWorker' in navigator) {
-                window.addEventListener('load', function() {
-                  navigator.serviceWorker.register('/sw.js')
-                    .then(function(registration) {
-                      console.log('SW registered: ', registration);
-                    }, function(registrationError) {
-                      console.log('SW registration failed: ', registrationError);
-                    });
-                });
-              }
-              
-              // Inicializar tratamento global de erros
-              ${initializeErrorHandling.toString()}
-              initializeErrorHandling();
-            `,
-          }}
-        />
+        <AppInitializer />
       </body>
     </html>
   );

--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect } from "react"
+import { initializeErrorHandling } from "@/lib/errorHandler"
+
+export default function AppInitializer() {
+  useEffect(() => {
+    // Initialize global error handling
+    initializeErrorHandling()
+
+    // Register service worker after window load
+    if (typeof window !== "undefined" && "serviceWorker" in navigator) {
+      const onLoad = () => {
+        navigator.serviceWorker
+          .register("/sw.js")
+          .then((registration) => {
+            console.log("SW registered: ", registration)
+          })
+          .catch((registrationError) => {
+            console.log("SW registration failed: ", registrationError)
+          })
+      }
+
+      window.addEventListener("load", onLoad)
+      return () => window.removeEventListener("load", onLoad)
+    }
+  }, [])
+
+  return null
+}


### PR DESCRIPTION
Move client-side initializations and update meta tags to fix a `ReferenceError` and address a deprecation warning.

The `Uncaught ReferenceError: initializeErrorHandling is not defined` occurred because the function was injected into an inline `<script>` tag in `layout.tsx` and called immediately, causing it to be out of scope. Moving this logic, along with the service worker registration, into a dedicated client component (`AppInitializer.tsx`) ensures it runs safely within the client's module scope after the component mounts. Additionally, the deprecated `apple-mobile-web-app-capable` meta tag was replaced with the recommended `mobile-web-app-capable`.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc148fef-358c-4d38-87cb-ca058bd6f161">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc148fef-358c-4d38-87cb-ca058bd6f161">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

