### PR TITLE
Analise erros do módulo pacientes

### DIFF
--- a/src/app/api/pacientes/route.ts
+++ b/src/app/api/pacientes/route.ts
@@ -15,7 +15,7 @@ export async function GET() {
       )
     }
 
-    const patients = await getUserPatients(session.user.id)
+    const patients = await getUserPatients(supabase, session.user.id)
     return NextResponse.json(patients)
 
   } catch (error) {
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
       genero
     }
 
-    const patient = await createPatient(session.user.id, patientData)
+    const patient = await createPatient(supabase, session.user.id, patientData)
     return NextResponse.json(patient, { status: 201 })
 
   } catch (error) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -71,12 +71,12 @@ export async function getCurrentUser() {
 }
 
 export async function getUserProfile(userId: string) {
-  const { data, error } = await supabase
+  const { data, error, status } = await supabase
     .from('perfis_usuarios')
     .select('*')
     .eq('user_id', userId)
-    .single()
+    .maybeSingle()
 
-  if (error) throw error
-  return data
+  if (error && status !== 406) throw error
+  return data ?? null
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,16 +1,16 @@
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { EnderecoEntrega, DadosEvento, Transcriptions, WakeWords, FHIRBundle, ResponseData, QualidadeConexao } from '@/types/database';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'http://localhost';
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? 'anon-key';
 
-if (!supabaseUrl || !supabaseAnonKey) {
+if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
   console.warn('Missing Supabase environment variables');
 }
 
 export const supabase = createClientComponentClient({
-  supabaseUrl: supabaseUrl ?? '',
-  supabaseKey: supabaseAnonKey ?? '',
+  supabaseUrl,
+  supabaseKey: supabaseAnonKey,
 });
 
 export type Database = {


### PR DESCRIPTION
Refactor patient module to use Supabase, fixing API 500 errors and gracefully handling missing user profiles.

The previous implementation relied on Prisma, which caused 500 errors in the `/api/pacientes` route due to a missing local database connection. This PR migrates the patient service to Supabase, resolving this issue. Additionally, `getUserProfile` was updated to prevent errors when a user profile does not yet exist (406 status), and the Supabase client initialization was made more robust for build environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ed2fc2a-8a7c-48e2-aadd-b29a9835cca2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ed2fc2a-8a7c-48e2-aadd-b29a9835cca2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

